### PR TITLE
Search and filter products endpoint

### DIFF
--- a/src/controller/products.controller.ts
+++ b/src/controller/products.controller.ts
@@ -16,6 +16,7 @@ import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiOperation, ApiParam, ApiQuery, ApiBody, ApiConsumes } from '@nestjs/swagger';
 import { CreateProductDto } from 'src/dto/create-product.dto';
 import { UpdateProductDto } from 'src/dto/update-product.dto';
+import { ProductSearchCriteriaDto } from 'src/dto/product-search-criteria.dto';
 
 @ApiTags('Products')
 @Controller('products')
@@ -160,5 +161,14 @@ export class ProductsController {
   @ApiBody({ schema: { type: 'array', items: { type: 'string' } } })
   async getProductsBatch(@Body() productIds: string[]) {
     return this.productsService.getProductsBatch(productIds);
+  }
+
+  @Post('search')
+  @ApiOperation({ summary: 'Search products with criteria' })
+  @ApiBody({ type: ProductSearchCriteriaDto })
+  async searchProducts(
+    @Body() criteria: ProductSearchCriteriaDto,
+  ) {
+    return this.productsService.searchProducts(criteria);
   }
 }

--- a/src/dto/product-search-criteria.dto.ts
+++ b/src/dto/product-search-criteria.dto.ts
@@ -1,0 +1,24 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ProductSearchCriteriaDto {
+  @ApiPropertyOptional({ example: 'sofa' })
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'MODERN' })
+  style?: string;
+
+  @ApiPropertyOptional({ type: [String], example: ['WOOD', 'FABRIC'] })
+  materials?: string[];
+
+  @ApiPropertyOptional({ example: 'name' })
+  sortBy?: string;
+
+  @ApiPropertyOptional({ example: 'asc', enum: ['asc', 'desc'] })
+  direction?: string;
+
+  @ApiPropertyOptional({ example: 0 })
+  page?: number;
+
+  @ApiPropertyOptional({ example: 20 })
+  size?: number;
+}

--- a/src/service/products.service.ts
+++ b/src/service/products.service.ts
@@ -55,4 +55,10 @@ export class ProductsService {
       this.http.patch(`${this.baseUrl}/${tenantId}/${productId}`, dto)
     );
   }
+
+  async searchProducts(criteria: any) {
+    return this.request(
+      this.http.post(`${this.baseUrl}/search`, criteria)
+    );
+  }
 }


### PR DESCRIPTION
This pull request introduces a new search endpoint to the API Gateway, enabling clients to search for products by name. The gateway now exposes a unified /products/search endpoint that seamlessly forwards search requests to the Products microservice.

### Main Changes
POST /products/search endpoint, implemented the new search endpoint.
Configured the gateway to forward the query parameter directly to the Products microservice's search functionality.
Ensured proper response mapping and error forwarding from the Products service back to the client.