### PR TITLE
Implement visualization with AR metric

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,8 @@ import { ConfigModule } from '@nestjs/config';
 
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
+import { MetricsService } from './service/metrics.service';
+import { MetricsController } from './controller/metrics.controller';
 
 @Module({
   imports: [
@@ -22,9 +24,13 @@ import { APP_GUARD } from '@nestjs/core';
     }),
     
   ],
-  controllers: [ProductsController],
+  controllers: [
+    ProductsController,
+    MetricsController
+  ],
   providers: [
     ProductsService,
+    MetricsService,
     MediaService,
     {
       provide: APP_GUARD,

--- a/src/controller/metrics.controller.ts
+++ b/src/controller/metrics.controller.ts
@@ -9,7 +9,7 @@ import {
 import { MetricsService } from 'src/service/metrics.service';
 import { Response } from 'express';
 
-@Controller('/v1/metrics')
+@Controller('/metrics')
 export class MetricsController {
   constructor(private readonly metricsService: MetricsService) {}
 
@@ -27,6 +27,26 @@ export class MetricsController {
   async registerClick(@Param('productId') productId: string, @Res() res: Response) {
     try {
       await this.metricsService.registerClick(productId);
+      return res.status(HttpStatus.OK).send();
+    } catch (error) {
+      return res.status(this.metricsService.mapError(error)).send();
+    }
+  }
+
+  @Post('ar-views/:productId')
+  async registerArView(@Param('productId') productId: string, @Res() res: Response) {
+    try {
+      await this.metricsService.registerArView(productId);
+      return res.status(HttpStatus.OK).send();
+    } catch (error) {
+      return res.status(this.metricsService.mapError(error)).send();
+    }
+  }
+
+  @Post('search-appearances/:productId')
+  async registerSearchAppearance(@Param('productId') productId: string, @Res() res: Response) {
+    try {
+      await this.metricsService.registerSearchAppearance(productId);
       return res.status(HttpStatus.OK).send();
     } catch (error) {
       return res.status(this.metricsService.mapError(error)).send();

--- a/src/service/metrics.service.ts
+++ b/src/service/metrics.service.ts
@@ -32,6 +32,18 @@ export class MetricsService {
     );
   }
 
+  async registerArView(productId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.post(`${this.baseUrl}/ar-views/${productId}`),
+    );
+  }
+
+  async registerSearchAppearance(productId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.post(`${this.baseUrl}/search-appearances/${productId}`),
+    );
+  }
+
   mapError(error: any): number {
     if (error?.response?.status) {
       return error.response.status;

--- a/src/service/products.service.ts
+++ b/src/service/products.service.ts
@@ -15,7 +15,7 @@ export class ProductsService {
     if (!baseUrl) {
       throw new Error('PRODUCTS_API_URL is not defined in environment variables');
     }
-    this.baseUrl = baseUrl;
+    this.baseUrl = `${baseUrl}/v1/products`;
   }
 
   async createProduct(data: any) {


### PR DESCRIPTION
This pull request adds API Gateway support for AR and search metrics tracking. Two new endpoints forward requests to the Products Service, allowing frontends to register engagement events.

### Main Changes:

- POST /metrics/ar-view/:productId
- POST /metrics/search-appearance/:productId
- Updated GET /metrics/:tenantId to include new fields.
- Used HttpService to forward requests and return responses.

