### PR TITLE
Get general metrics summary

### DIFF
--- a/src/controller/metrics.controller.ts
+++ b/src/controller/metrics.controller.ts
@@ -1,55 +1,65 @@
 import {
-  Controller,
-  Get,
-  Param,
-  Post,
-  Res,
-  HttpStatus,
+    Controller,
+    Get,
+    Param,
+    Post,
+    Res,
+    HttpStatus,
 } from '@nestjs/common';
 import { MetricsService } from 'src/service/metrics.service';
 import { Response } from 'express';
 
 @Controller('/metrics')
 export class MetricsController {
-  constructor(private readonly metricsService: MetricsService) {}
+    constructor(private readonly metricsService: MetricsService) { }
 
-  @Get(':productId')
-  async getProductMetric(@Param('productId') productId: string, @Res() res: Response) {
-    try {
-      const metric = await this.metricsService.getProductMetric(productId);
-      return res.status(HttpStatus.OK).json(metric);
-    } catch (error) {
-      return res.status(this.metricsService.mapError(error)).send();
+    @Get(':productId')
+    async getProductMetric(@Param('productId') productId: string, @Res() res: Response) {
+        try {
+            const metric = await this.metricsService.getProductMetric(productId);
+            return res.status(HttpStatus.OK).json(metric);
+        } catch (error) {
+            return res.status(this.metricsService.mapError(error)).send();
+        }
     }
-  }
 
-  @Post('click/:productId')
-  async registerClick(@Param('productId') productId: string, @Res() res: Response) {
-    try {
-      await this.metricsService.registerClick(productId);
-      return res.status(HttpStatus.OK).send();
-    } catch (error) {
-      return res.status(this.metricsService.mapError(error)).send();
+    @Post('click/:productId')
+    async registerClick(@Param('productId') productId: string, @Res() res: Response) {
+        try {
+            await this.metricsService.registerClick(productId);
+            return res.status(HttpStatus.OK).send();
+        } catch (error) {
+            return res.status(this.metricsService.mapError(error)).send();
+        }
     }
-  }
 
-  @Post('ar-views/:productId')
-  async registerArView(@Param('productId') productId: string, @Res() res: Response) {
-    try {
-      await this.metricsService.registerArView(productId);
-      return res.status(HttpStatus.OK).send();
-    } catch (error) {
-      return res.status(this.metricsService.mapError(error)).send();
+    @Post('ar-views/:productId')
+    async registerArView(@Param('productId') productId: string, @Res() res: Response) {
+        try {
+            await this.metricsService.registerArView(productId);
+            return res.status(HttpStatus.OK).send();
+        } catch (error) {
+            return res.status(this.metricsService.mapError(error)).send();
+        }
     }
-  }
 
-  @Post('search-appearances/:productId')
-  async registerSearchAppearance(@Param('productId') productId: string, @Res() res: Response) {
-    try {
-      await this.metricsService.registerSearchAppearance(productId);
-      return res.status(HttpStatus.OK).send();
-    } catch (error) {
-      return res.status(this.metricsService.mapError(error)).send();
+    @Post('search-appearances/:productId')
+    async registerSearchAppearance(@Param('productId') productId: string, @Res() res: Response) {
+        try {
+            await this.metricsService.registerSearchAppearance(productId);
+            return res.status(HttpStatus.OK).send();
+        } catch (error) {
+            return res.status(this.metricsService.mapError(error)).send();
+        }
     }
-  }
+
+    @Get('report/:tenantId')
+    async getTenantReport(@Param('tenantId') tenantId: string, @Res() res: Response) {
+        try {
+            const report = await this.metricsService.getTenantMetricsReport(tenantId);
+            return res.status(HttpStatus.OK).json(report);
+        } catch (error) {
+            return res.status(this.metricsService.mapError(error)).send();
+        }
+    }
 }

--- a/src/service/metrics.service.ts
+++ b/src/service/metrics.service.ts
@@ -6,51 +6,58 @@ import { AxiosError } from 'axios';
 
 @Injectable()
 export class MetricsService {
-  private readonly baseUrl: string;
+    private readonly baseUrl: string;
 
-  constructor(
-    private readonly http: HttpService,
-    private readonly configService: ConfigService,
-  ) {
-    const url = this.configService.get<string>('PRODUCTS_API_URL');
-    if (!url) {
-      throw new Error('PRODUCTS_API_URL is not defined in environment variables');
+    constructor(
+        private readonly http: HttpService,
+        private readonly configService: ConfigService,
+    ) {
+        const url = this.configService.get<string>('PRODUCTS_API_URL');
+        if (!url) {
+            throw new Error('PRODUCTS_API_URL is not defined in environment variables');
+        }
+        this.baseUrl = `${url}/v1/metrics`;
     }
-    this.baseUrl = `${url}/v1/metrics`;
-  }
 
-  async getProductMetric(productId: string): Promise<any> {
-    const response = await firstValueFrom(
-      this.http.get(`${this.baseUrl}/${productId}`),
-    );
-    return response.data;
-  }
-
-  async registerClick(productId: string): Promise<void> {
-    await firstValueFrom(
-      this.http.post(`${this.baseUrl}/click/${productId}`),
-    );
-  }
-
-  async registerArView(productId: string): Promise<void> {
-    await firstValueFrom(
-      this.http.post(`${this.baseUrl}/ar-views/${productId}`),
-    );
-  }
-
-  async registerSearchAppearance(productId: string): Promise<void> {
-    await firstValueFrom(
-      this.http.post(`${this.baseUrl}/search-appearances/${productId}`),
-    );
-  }
-
-  mapError(error: any): number {
-    if (error?.response?.status) {
-      return error.response.status;
+    async getProductMetric(productId: string): Promise<any> {
+        const response = await firstValueFrom(
+            this.http.get(`${this.baseUrl}/${productId}`),
+        );
+        return response.data;
     }
-    if (error instanceof AxiosError) {
-      return error.response?.status || 500;
+
+    async registerClick(productId: string): Promise<void> {
+        await firstValueFrom(
+            this.http.post(`${this.baseUrl}/click/${productId}`),
+        );
     }
-    return 500;
-  }
+
+    async registerArView(productId: string): Promise<void> {
+        await firstValueFrom(
+            this.http.post(`${this.baseUrl}/ar-views/${productId}`),
+        );
+    }
+
+    async registerSearchAppearance(productId: string): Promise<void> {
+        await firstValueFrom(
+            this.http.post(`${this.baseUrl}/search-appearances/${productId}`),
+        );
+    }
+
+    async getTenantMetricsReport(tenantId: string): Promise<any> {
+        const response = await firstValueFrom(
+            this.http.get(`${this.baseUrl}/report/${tenantId}`)
+        );
+        return response.data;
+    }
+
+    mapError(error: any): number {
+        if (error?.response?.status) {
+            return error.response.status;
+        }
+        if (error instanceof AxiosError) {
+            return error.response?.status || 500;
+        }
+        return 500;
+    }
 }

--- a/src/service/products.service.ts
+++ b/src/service/products.service.ts
@@ -11,11 +11,11 @@ export class ProductsService {
     private readonly http: HttpService,
     private readonly configService: ConfigService,
   ) {
-    const baseUrl = this.configService.get<string>('PRODUCTS_API_URL');
-    if (!baseUrl) {
+    const url = this.configService.get<string>('PRODUCTS_API_URL');
+    if (!url) {
       throw new Error('PRODUCTS_API_URL is not defined in environment variables');
     }
-    this.baseUrl = `${baseUrl}/v1/products`;
+    this.baseUrl = `${url}/v1/products`;
   }
 
   async createProduct(data: any) {


### PR DESCRIPTION
This pull request adds a new route to the API Gateway to allow external clients (such as the Admin Dashboard) to retrieve a summary of product metrics for a specific tenant.

### Main Changes:
Added GET /metrics/summary/:tenantId route to the API Gateway.

- Forwarded the request to the Products Service’s new summary endpoint.
- Passed the response directly without modification.
- Handled gateway-level error and timeout cases.